### PR TITLE
Distilled Model - Embeddings txt src

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ endif(COMPILE_TESTS)
 
 add_subdirectory(3rd_party)
 add_subdirectory(src)
+add_subdirectory(distilled)
 
 if(COMPILE_WASM)
   add_subdirectory(wasm)

--- a/distilled/CMakeLists.txt
+++ b/distilled/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.5.1)
+
+project(Distilled C CXX)
+
+add_executable(DistilledModel main.cpp)
+target_link_libraries(DistilledModel dl marian ssplit)
+
+

--- a/distilled/compare_marian_with_deepquest.py
+++ b/distilled/compare_marian_with_deepquest.py
@@ -1,0 +1,7 @@
+import numpy
+
+marian_results = numpy.load('distillied_marian_results.npz')
+deep_quest_results = numpy.load('distillied_py_results.npz')
+
+assert numpy.allclose(marian_results['embedded_text_src'],
+                      deep_quest_results['embedded_text_src'], atol=1e-6)

--- a/distilled/dp2marian.py
+++ b/distilled/dp2marian.py
@@ -1,0 +1,25 @@
+
+"""
+This script converts the distilled model weights trained in python(torch) to a marian weights file (npz)
+The distilled model files is listed on: 
+  - https://github.com/sheffieldnlp/deepQuest-py/tree/main/examples/knowledge_distillation#trained-student-models
+
+usage:
+  python3 dp2marian.py --model weights.th  --output distilled.npz
+"""
+
+import torch
+import numpy
+import argparse
+
+parser = argparse.ArgumentParser(description='Convert distilled model weights to Marian weight file.')
+parser.add_argument('--model', help='Distilled model path', required=True)
+parser.add_argument('--output', help='Marian output path', required=True)
+args = parser.parse_args()
+
+dpModel = torch.load(args.model,map_location=torch.device('cpu') )
+
+marianModel = {}
+marianModel[ 'embeddings_txt_src'] = dpModel['_text_field_embedder_src.token_embedder_tokens.weight']
+
+numpy.savez(args.output, **marianModel)

--- a/distilled/main.cpp
+++ b/distilled/main.cpp
@@ -1,0 +1,58 @@
+
+#include <algorithm>
+
+#include "layers/generic.h"
+#include "marian.h"
+#include "models/decoder.h"
+#include "models/encoder.h"
+#include "models/model_factory.h"
+#include "models/s2s.h"
+
+using namespace marian;
+
+std::string work_dir = "/workspaces/bergamot/bergamot-translator/distilled";
+
+void createGraph(Ptr<ExpressionGraph>& graph, const Words& tokens_src, const int dim_vocab) {
+  // https://github.com/sheffieldnlp/deepQuest-py/blob/main/deepquestpy/config/birnn.jsonnet#L28
+  const int dim_emb = 50;
+  const int dim_batch = 1;
+
+  const auto tokens_src_dim = static_cast<int>(tokens_src.size());
+
+  auto embeddings_txt_src = graph->param("embeddings_txt_src", {dim_vocab, dim_emb}, inits::glorotUniform());
+  auto embedded_txt_src =
+      reshape(rows(embeddings_txt_src, toWordIndexVector(tokens_src)), {dim_batch, tokens_src_dim, dim_emb});
+
+  std::cout << graph->graphviz() << std::endl;
+
+  graph->forward();
+
+  graph->save(work_dir + "/distilled.npz");
+
+  std::vector<float> values;
+
+  embedded_txt_src->val()->get(values);
+
+  std::cout << values.size() << std::endl;
+}
+
+int main(const int argc, const char* argv[]) {
+  createLoggers();
+
+  auto graph = New<ExpressionGraph>();
+
+  graph->setDevice({0, DeviceType::cpu});
+  graph->reserveWorkspaceMB(128);
+
+  marian::Vocab vocab(New<Options>(), 0);
+  vocab.load("/workspaces/bergamot/attentions/vocab.eten.spm");
+
+  // Source Input
+  const auto tokens_src = vocab.encode("Pärast Portugali Vabariigi väljakuulutamist võeti 1911. aastal kasutusele uus rahaühik eskuudo , mis jagunes 100 sentaavoks .");
+
+  const auto dim_vocab = static_cast<int>(vocab.size());
+
+  createGraph(graph, tokens_src, dim_vocab);
+
+  return 0;
+}

--- a/distilled/main.cpp
+++ b/distilled/main.cpp
@@ -1,4 +1,3 @@
-
 #include <algorithm>
 
 #include "layers/generic.h"
@@ -16,18 +15,21 @@ void createGraphParams(Ptr<ExpressionGraph>& graph, const int dim_vocab, const i
   graph->param("embeddings_txt_src", {dim_vocab, dim_emb}, inits::glorotUniform());
 }
 
-void forward(Ptr<ExpressionGraph>& graph, const std::vector<WordIndex>& tokens_src, const int dim_emb) {
+void saveResults(const std::vector<std::pair<std::string, Expr> >& exprs);
 
+void forward(Ptr<ExpressionGraph>& graph, const std::vector<WordIndex>& tokens_src, const int dim_emb) {
   const int dim_batch = 1;
   const int dim_tokens_src = tokens_src.size();
 
   auto embeddings_txt_src = graph->get("embeddings_txt_src");
 
-  auto embedded_txt_src = reshape(rows(embeddings_txt_src, tokens_src), {dim_batch, dim_tokens_src, dim_emb});
-  
-  debug( embedded_txt_src, "embedded_txt_src");
+  auto embedded_text_src = reshape(rows(embeddings_txt_src, tokens_src), {dim_batch, dim_tokens_src, dim_emb});
+
+  debug(embedded_text_src, "embedded_text_src");
 
   graph->forward();
+
+  saveResults({{"embedded_text_src", embedded_text_src}});
 }
 
 int main(const int argc, const char* argv[]) {
@@ -43,10 +45,10 @@ int main(const int argc, const char* argv[]) {
 
   // Tokenize source input by marian vocab
   // https://data.statmt.org/bergamot/models/eten/
-  
+
   marian::Vocab vocab(New<Options>(), 0);
   vocab.load("/workspaces/bergamot/attentions/vocab.eten.spm");
-  
+
   const auto tokens_word_src = vocab.encode(
       "Pärast Portugali Vabariigi väljakuulutamist võeti 1911. aastal kasutusele uus rahaühik eskuudo , mis jagunes "
       "100 sentaavoks .");
@@ -60,13 +62,25 @@ int main(const int argc, const char* argv[]) {
 
   // Load converted python model
   graph->load(work_dir + "/distilled.npz");
-  
+
   // Simulating the python tokenizer
   dim_vocab = 31781;
-  tokens_src = {1, 1, 1, 1, 118,  1, 1, 3061, 1, 1,    1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                3, 1, 1, 1, 1542, 1, 1, 1,    1, 1542, 1, 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  tokens_src = {1, 1, 1, 1, 118, 1, 1, 3061, 1,    1, 1, 1, 2, 1,    1, 1, 1, 1, 1,
+                1, 1, 1, 1, 3,   1, 1, 1,    1542, 1, 1, 1, 1, 1542, 1, 2, 1, 1};
 
   forward(graph, tokens_src, dim_emb);
 
   return 0;
+}
+
+void saveResults(const std::vector<std::pair<std::string, Expr> >& exprs) {
+  std::vector<io::Item> items;
+
+  std::transform(std::begin(exprs), std::end(exprs), std::back_inserter(items), [](const auto& expr) {
+    io::Item item;
+    expr.second->val()->get(item, expr.first);
+    return item;
+  });
+
+  io::saveItems(work_dir + "/distillied_marian_results.npz", items);
 }


### PR DESCRIPTION
- This PR creates a project on bergamot-translator/distilled to port deepQuest-py model [deepQuest-py birnn](https://github.com/sheffieldnlp/deepQuest-py) to Marian
- In [deepQuest-py birnn](https://github.com/sheffieldnlp/deepQuest-py/blob/main/deepquestpy/models/birnn.py) the `source` and `target` models have the same flow before the `concat` operation, so for the first part we will focus on `source` portability only. Then, we will tokenize the source input by vocab class on marian and create the graph with the embedding text source. 

- To illustrate the model flow, we are using a ET-EN tokenizers,for both cases. However, they are not the same for marian and deepQuest. This is not a blocker and we have plans to make them using the same one in the future

- Obs: We used a `snake_case` format to show exactly witch operation we are doing from `deepQuest-py birnn`.


### DeepQuest-py

1. The tokens_src are the tokens from the text source after apply the tokenization process .
   - For this test case we ran the `evaluate.sh` script from the repository, which calls the model inference on a sample test data. By default, the batch size is 32 and the sentence size of a given batch is set to be the longest sequence on that batch 

![photo_2021-12-14_22-09-53](https://user-images.githubusercontent.com/42920697/146104361-3f1ebead-4b24-45a1-93b6-a474be9bf84d.jpg)


2. The `text_field_embedder_src` has a embedding parameter which contains two variables,  `A`, where A is the number o tokens on vocab and `B`, which  is the size of the embedding dimension defined on [configuration file](https://github.com/sheffieldnlp/deepQuest-py/blob/main/deepquestpy/config/birnn.jsonnet#L28)

3. In the ends, the process generates `embedded_text_source` with the following shape.

![photo_2021-12-14_22-10-07](https://user-images.githubusercontent.com/42920697/146105655-2e491053-6a49-4272-8e2c-8310c3ee9029.jpg)

### Marian

1. On marian we create a vocab class and tokenize the input and we decided to maintain the batch size equal to 1
2. For the embedding we follow the same operations from the unit test (https://github.com/marian-nmt/marian-dev/blob/master/src/tests/units/rnn_tests.cpp).
3. In the ends generates embedded text source the following shape.

![Screenshot from 2021-12-15 21-51-27](https://user-images.githubusercontent.com/42920697/146287912-42dfb32e-e150-4235-a7ec-3c20585ad2db.png)

