### PR TITLE
Implements source linear layer and creates birnn and utils

### DIFF
--- a/distilled/CMakeLists.txt
+++ b/distilled/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.1)
 
 project(Distilled C CXX)
 
-add_executable(DistilledModel main.cpp)
+add_executable(DistilledModel main.cpp birnn.cpp utils.cpp)
 target_link_libraries(DistilledModel dl marian ssplit)
 
 

--- a/distilled/birnn.cpp
+++ b/distilled/birnn.cpp
@@ -1,0 +1,65 @@
+
+
+#include "birnn.h"
+
+#include "models/decoder.h"
+#include "models/encoder.h"
+#include "models/model_factory.h"
+#include "models/s2s.h"
+#include "utils.h"
+
+namespace distilled::birnn {
+   
+Exprs forward(Ptr<ExpressionGraph>& graph, const std::vector<WordIndex>& tokens_src, const int dim_emb,
+              const std::vector<float>& mask_src) {
+  const int dim_batch = 1;
+  const int dim_tokens_src = tokens_src.size();
+  
+  auto embedded_text_src = text_field_embedder_src( graph, tokens_src, dim_batch, dim_emb );
+
+  auto encoded_text_src = seq2seq_encoder_src(graph, embedded_text_src, dim_emb, mask_src );
+
+  auto encoded_text_src_linear_op =  linear_layer_src(graph, encoded_text_src);
+  
+  std::cout << graph->graphviz() << std::endl;  
+  
+  graph->forward();
+
+  return {{"embedded_text_src", embedded_text_src},
+          {"encoded_text_src", encoded_text_src},
+          {"encoded_text_src_linear_op", encoded_text_src_linear_op}};
+}
+   
+Expr text_field_embedder_src(Ptr<ExpressionGraph>& graph, const std::vector<WordIndex>& tokens_src, const int dim_batch,
+                             const int dim_emb) {
+  const int dim_tokens_src = tokens_src.size();
+
+  auto embeddings_txt_src = graph->get("embeddings_txt_src");
+
+  auto embedded_text_src = reshape(rows(embeddings_txt_src, tokens_src), {dim_batch, dim_tokens_src, dim_emb});
+
+  return embedded_text_src;
+}
+
+Expr seq2seq_encoder_src(Ptr<ExpressionGraph>& graph, const Expr& embedded_text_src, const int dim_emb,
+                         const std::vector<float>& mask_src) {
+  auto options =
+      New<Options>("enc-depth", 1, "dropout-rnn", 0.0f, "enc-cell", "gru", "dim-rnn", dim_emb, "layer-normalization",
+                   false, "skip", false, "enc-cell-depth", 1, "prefix", "encoder_s2s_text_src", "hidden-bias", true);
+
+  marian::EncoderS2S encoderS2S(graph, options);
+
+  auto embedded_text_src_t = transpose(embedded_text_src, {1, 0, 2});
+
+  auto mask_src_expr = graph->constant({static_cast<int>(mask_src.size()), 1, 1}, marian::inits::fromVector(mask_src));
+
+  auto encoded_text_src_t = encoderS2S.applyEncoderRNN(graph, embedded_text_src_t, mask_src_expr, "bidirectional");
+
+  return transpose(encoded_text_src_t, {1, 0, 2});
+}
+
+Expr linear_layer_src(Ptr<ExpressionGraph>& graph, const Expr& encoded_text_src) {
+  return linear(encoded_text_src, graph->get("linear_layer_src_weight"), graph->get("linear_layer_src_bias"));
+}
+
+}  // namespace distilled::birnn

--- a/distilled/birnn.h
+++ b/distilled/birnn.h
@@ -1,0 +1,20 @@
+
+
+#pragma once
+
+#include "utils.h"
+
+namespace distilled::birnn {
+   
+Exprs forward(Ptr<ExpressionGraph>& graph, const std::vector<WordIndex>& tokens_src, const int dim_emb,
+              const std::vector<float>& mask_src);
+                 
+Expr text_field_embedder_src(Ptr<ExpressionGraph>& graph, const std::vector<WordIndex>& tokens_src, const int dim_batch,
+                             const int dim_emb);
+
+Expr seq2seq_encoder_src(Ptr<ExpressionGraph>& graph, const Expr& embedded_text_src, const int dim_emb,
+                         const std::vector<float>& mask_src);
+                         
+Expr linear_layer_src( Ptr<ExpressionGraph>& graph, const Expr& encoded_text_src );
+
+}  // namespace distilled::birnn

--- a/distilled/compare_marian_with_deepquest.py
+++ b/distilled/compare_marian_with_deepquest.py
@@ -15,4 +15,7 @@ assert numpy.allclose(marian_results['embedded_text_src'],
 assert numpy.allclose(marian_results['encoded_text_src'],
                       deep_quest_results['encoded_text_src'], atol=1e-6)
 
+assert numpy.allclose(marian_results['encoded_text_src_linear_op'],
+                      deep_quest_results['encoded_text_src_linear_op'], atol=1e-6)
+
 print("Success")

--- a/distilled/dp2marian.py
+++ b/distilled/dp2marian.py
@@ -1,0 +1,42 @@
+
+"""
+This script converts the distilled model weights trained in python(torch) to a marian weights file (npz)
+The distilled model files is listed on: 
+  - https://github.com/sheffieldnlp/deepQuest-py/tree/main/examples/knowledge_distillation#trained-student-models
+
+usage:
+  python3 dp2marian.py --model weights.th  --output distilled.npz
+"""
+
+import torch
+import numpy
+import argparse
+
+def as_rowmajor(a):
+  return numpy.array(a, order='C', dtype=numpy.float32)
+
+parser = argparse.ArgumentParser(description='Convert distilled model weights to Marian weight file.')
+parser.add_argument('--model', help='Distilled model path', required=True)
+parser.add_argument('--output', help='Marian output path', required=True)
+args = parser.parse_args()
+
+dpModel = torch.load(args.model,map_location=torch.device('cpu') )
+
+marianModel = {}
+
+# Embedding
+marianModel[ 'embeddings_txt_src'] = as_rowmajor(dpModel['_text_field_embedder_src.token_embedder_tokens.weight'])
+
+# Seq2Seq source Encoder
+marianModel[ 'encoder_s2s_text_src_bi_W'] = as_rowmajor(dpModel['seq2seq_encoder_src._module.weight_ih_l0'].T)
+marianModel[ 'encoder_s2s_text_src_bi_b'] = as_rowmajor(dpModel['seq2seq_encoder_src._module.bias_ih_l0'].T)
+
+marianModel[ 'encoder_s2s_text_src_bi_U'] = as_rowmajor(dpModel['seq2seq_encoder_src._module.weight_hh_l0'].T)
+marianModel[ 'encoder_s2s_text_src_bi_bu'] = as_rowmajor(dpModel['seq2seq_encoder_src._module.bias_hh_l0'].T)
+
+marianModel[ 'encoder_s2s_text_src_bi_r_W'] = as_rowmajor(dpModel['seq2seq_encoder_src._module.weight_ih_l0_reverse'].T)
+marianModel[ 'encoder_s2s_text_src_bi_r_U'] = as_rowmajor(dpModel['seq2seq_encoder_src._module.weight_hh_l0_reverse'].T)
+marianModel[ 'encoder_s2s_text_src_bi_r_b'] = as_rowmajor(dpModel['seq2seq_encoder_src._module.bias_ih_l0_reverse'].T)
+marianModel[ 'encoder_s2s_text_src_bi_r_bu'] = as_rowmajor(dpModel['seq2seq_encoder_src._module.bias_hh_l0_reverse'].T)
+
+numpy.savez(args.output, **marianModel)

--- a/distilled/dq2marian.py
+++ b/distilled/dq2marian.py
@@ -50,14 +50,14 @@ dqModel = torch.load(args.model, map_location=torch.device("cpu"))
 
 marianModel = {}
 
-# Embedding
+# Source Embedding
 marianModel["embeddings_txt_src"] = as_rowmajor(
     dqModel["_text_field_embedder_src.token_embedder_tokens.weight"]
 )
 
 dimEmb = marianModel["embeddings_txt_src"].shape[1]
 
-# Seq2Seq source Encoder
+# Source Seq2Seq Encoder
 seq2seq_weights_conversion(
     dqModel,
     marianModel,
@@ -74,6 +74,8 @@ seq2seq_weights_conversion(
     dimEmb,
 )
 
-# marianModel['encoder_s2s_text_src_bi_r_bu'] = as_rowmajor(dqModel['seq2seq_encoder_src._module.bias_hh_l0_reverse'].T)
+# Source Linear Layer
+marianModel["linear_layer_src_weight"] = as_rowmajor( dqModel["_linear_layer_src.weight"])
+marianModel["linear_layer_src_bias"] = as_rowmajor( dqModel["_linear_layer_src.bias"])
 
 numpy.savez(args.output, **marianModel)

--- a/distilled/main.cpp
+++ b/distilled/main.cpp
@@ -2,23 +2,8 @@
 #include <vector>
 
 #include "CLI/CLI.hpp"
-#include "layers/generic.h"
-#include "marian.h"
-#include "models/decoder.h"
-#include "models/encoder.h"
-#include "models/model_factory.h"
-#include "models/s2s.h"
 
-using namespace marian;
-using Exprs = std::vector<std::pair<std::string, Expr> >;
-
-void createGraphParams(Ptr<ExpressionGraph>& graph, const int dim_vocab, const int dim_emb) {
-  graph->param("embeddings_txt_src", {dim_vocab, dim_emb}, inits::glorotUniform());
-}
-
-void saveResults(const std::string& filePath, const Exprs& exprs);
-Exprs forward(Ptr<ExpressionGraph>& graph, const std::vector<WordIndex>& tokens_src, const int dim_emb,
-              const std::vector<float>& mask_src);
+#include "birnn.h"
 
 int main(const int argc, const char* argv[]) {
   std::string modelPath;
@@ -54,9 +39,6 @@ int main(const int argc, const char* argv[]) {
   auto tokens_src = toWordIndexVector(tokens_word_src);
   std::vector<float> mask_src(tokens_src.size(), 1.0);
 
-  // // Create randon params
-  // forward(graph, tokens_src, dim_emb, mask);
-
   // Load converted python model
   graph->load(modelPath);
 
@@ -68,65 +50,11 @@ int main(const int argc, const char* argv[]) {
   mask_src = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
               1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
 
-  // createGraphParams( graph, dim_vocab, dim_emb);
-
-  const auto results = forward(graph, tokens_src, dim_emb, mask_src);
+  const auto results = distilled::birnn::forward(graph, tokens_src, dim_emb, mask_src);
 
   if (!outputPath.empty()) {
-    saveResults(outputPath, results);
+    distilled::saveResults(outputPath, results);
   }
 
   return 0;
-}
-
-Exprs forward(Ptr<ExpressionGraph>& graph, const std::vector<WordIndex>& tokens_src, const int dim_emb,
-              const std::vector<float>& mask_src) {
-  const int dim_batch = 1;
-  const int dim_tokens_src = tokens_src.size();
-
-  // Source Embedding
-  auto embeddings_txt_src = graph->get("embeddings_txt_src");
-
-  auto embedded_text_src = reshape(rows(embeddings_txt_src, tokens_src), {dim_batch, dim_tokens_src, dim_emb});
-
-  // Source Seq2seq Encoder
-  auto options =
-      New<Options>("enc-depth", 1, "dropout-rnn", 0.0f, "enc-cell", "gru", "dim-rnn", dim_emb, "layer-normalization",
-                   false, "skip", false, "enc-cell-depth", 1, "prefix", "encoder_s2s_text_src", "hidden-bias", true);
-
-  marian::EncoderS2S encoderS2S(graph, options);
-
-  auto embedded_text_src_t = transpose(embedded_text_src, {1, 0, 2});
-
-  auto mask_src_expr = graph->constant({static_cast<int>(mask_src.size()), 1, 1}, marian::inits::fromVector(mask_src));
-
-  auto encoded_text_src_t = encoderS2S.applyEncoderRNN(graph, embedded_text_src_t, mask_src_expr, "bidirectional");
-
-  auto encoded_text_src = transpose(encoded_text_src_t, {1, 0, 2});
-
-  // Source Linear Layer
-  auto linear_layer_src_weight = graph->get("linear_layer_src_weight");
-  auto linear_layer_src_bias = graph->get("linear_layer_src_bias");
-
-  auto encoded_text_src_linear_op = dot(encoded_text_src, linear_layer_src_weight, false, true) + linear_layer_src_bias;
-
-  std::cout << graph->graphviz() << std::endl;
-
-  graph->forward();
-
-  return {{"embedded_text_src", embedded_text_src},
-          {"encoded_text_src", encoded_text_src},
-          {"encoded_text_src_linear_op", encoded_text_src_linear_op}};
-}
-
-void saveResults(const std::string& filePath, const Exprs& exprs) {
-  std::vector<io::Item> items;
-
-  std::transform(std::begin(exprs), std::end(exprs), std::back_inserter(items), [](const auto& expr) {
-    io::Item item;
-    expr.second->val()->get(item, expr.first);
-    return item;
-  });
-
-  io::saveItems(filePath, items);
 }

--- a/distilled/utils.cpp
+++ b/distilled/utils.cpp
@@ -1,0 +1,21 @@
+
+
+#include "utils.h"
+
+namespace distilled {
+
+Expr linear(const Expr& x, const Expr& A, const Expr b) { return dot(x, A, false, true) + b; }
+
+void saveResults(const std::string& filePath, const Exprs& exprs) {
+  std::vector<io::Item> items;
+
+  std::transform(std::begin(exprs), std::end(exprs), std::back_inserter(items), [](const auto& expr) {
+    io::Item item;
+    expr.second->val()->get(item, expr.first);
+    return item;
+  });
+
+  io::saveItems(filePath, items);
+}
+
+}  // namespace distilled

--- a/distilled/utils.h
+++ b/distilled/utils.h
@@ -1,0 +1,18 @@
+
+
+#pragma once
+
+#include "marian.h"
+
+using namespace marian;
+
+using Exprs = std::vector<std::pair<std::string, Expr> >;
+
+namespace distilled {
+   
+   // https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
+   Expr linear( const Expr& x, const Expr& A, const Expr b);
+   
+   void saveResults(const std::string& filePath, const Exprs& exprs);
+
+}  // namespace distilled::birnn


### PR DESCRIPTION
This PR implements:

- The source linear layer and it converts the operation weights to marian.
- The source linear layer implementation is in [this location](https://github.com/felipesantosk/bergamot-translator/pull/4/files#diff-dfe5f81b7b964342506fd52451a54bad5c4145ddda7d56de5dccd4b567645666R61)
- Moves the  birnn implementation to `birnn.cpp/h ` files and split the implementaion in methods.
- Created a utils file with helper functions
- The comparison, successfully passed.

