### PR TITLE
DistilledMode - Adds a source attention and new helper methods

### DIFF
--- a/distilled/birnn.h
+++ b/distilled/birnn.h
@@ -5,16 +5,18 @@
 #include "utils.h"
 
 namespace distilled::birnn {
-   
+
 Exprs forward(Ptr<ExpressionGraph>& graph, const std::vector<WordIndex>& tokens_src, const int dim_emb,
               const std::vector<float>& mask_src);
-                 
+
 Expr text_field_embedder_src(Ptr<ExpressionGraph>& graph, const std::vector<WordIndex>& tokens_src, const int dim_batch,
                              const int dim_emb);
 
 Expr seq2seq_encoder_src(Ptr<ExpressionGraph>& graph, const Expr& embedded_text_src, const int dim_emb,
                          const std::vector<float>& mask_src);
-                         
-Expr linear_layer_src( Ptr<ExpressionGraph>& graph, const Expr& encoded_text_src );
+
+Expr linear_layer_src(Ptr<ExpressionGraph>& graph, const Expr& encoded_text_src);
+
+Expr attention(const Expr& context_weights, const Expr& encoded_text);
 
 }  // namespace distilled::birnn

--- a/distilled/dq2marian.py
+++ b/distilled/dq2marian.py
@@ -78,4 +78,8 @@ seq2seq_weights_conversion(
 marianModel["linear_layer_src_weight"] = as_rowmajor( dqModel["_linear_layer_src.weight"])
 marianModel["linear_layer_src_bias"] = as_rowmajor( dqModel["_linear_layer_src.bias"])
 
+# Source attention
+marianModel["context_weights_src"] = as_rowmajor( dqModel["context_weights_src"])
+
+
 numpy.savez(args.output, **marianModel)

--- a/distilled/utils.cpp
+++ b/distilled/utils.cpp
@@ -6,6 +6,36 @@ namespace distilled {
 
 Expr linear(const Expr& x, const Expr& A, const Expr b) { return dot(x, A, false, true) + b; }
 
+Expr squeeze(const Expr& input, const int dim) {
+  if (input->shape()[dim] != 1) {
+    return input;
+  }
+
+  std::vector<int> newShape;
+  std::copy(std::begin(input->shape()), std::end(input->shape()), std::back_inserter(newShape));
+
+  if (dim < 0) {
+    newShape.erase(newShape.end() - abs(dim));
+  } else {
+    newShape.erase(newShape.begin() + dim);
+  }
+
+  return reshape(input, Shape(std::move(newShape)));
+}
+
+Expr unsqueeze(const Expr& input, const int dim) {
+  if ((dim < -1) || (dim > static_cast<int>(input->shape().size() + 1))) {
+    throw std::runtime_error("Invalid dimension size");
+  }
+
+  std::vector<int> newShape;
+  std::copy(std::begin(input->shape()), std::end(input->shape()), std::back_inserter(newShape));
+
+  newShape.insert((dim == -1) ? newShape.end() : (newShape.begin() + dim), 1);
+
+  return reshape(input, Shape(std::move(newShape)));
+}
+
 void saveResults(const std::string& filePath, const Exprs& exprs) {
   std::vector<io::Item> items;
 

--- a/distilled/utils.h
+++ b/distilled/utils.h
@@ -9,10 +9,16 @@ using namespace marian;
 using Exprs = std::vector<std::pair<std::string, Expr> >;
 
 namespace distilled {
-   
-   // https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
-   Expr linear( const Expr& x, const Expr& A, const Expr b);
-   
-   void saveResults(const std::string& filePath, const Exprs& exprs);
 
-}  // namespace distilled::birnn
+// https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
+Expr linear(const Expr& x, const Expr& A, const Expr b);
+
+// https://pytorch.org/docs/stable/generated/torch.squeeze.html
+Expr squeeze(const Expr& input, const int dim);
+
+// https://pytorch.org/docs/stable/generated/torch.unsqueeze.html
+Expr unsqueeze(const Expr& input, const int dim);
+
+void saveResults(const std::string& filePath, const Exprs& exprs);
+
+}  // namespace distilled


### PR DESCRIPTION
This PR implements the source attention step and it adds helper methods, `squeeze` and `unsqueeze`  following the torch methods.

The comparison, successfully passed.